### PR TITLE
draft: introduce distribute-only-peer

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -142,7 +142,7 @@ Once the Contract is signed by all the Peers, the Outway of the Delegatee can co
 
 ## Consuming a Service
 
-A Peer can consume a Service by sending request for said Service to an Outway. 
+A Peer can consume a Service by sending a request for said Service to an Outway. 
 The Peer obtains an access token from the Manager of the Peer providing the Service. 
 The Outway proxies the request including the access token to the Inway.
 The Inway will validate the access token and proxy the request to the Service.
@@ -157,6 +157,15 @@ The Inway will validate the access token and proxy the request to the Service.
 6. The Inway returns the response to the Outway.
 7. The Outway returns the response to the client.
 
+## Distribute-Only-Peer
+
+A Distribute-Only-Peer is a Peer who participates only to create and/or sign Contracts. The usecase for this Peer type is an organization who acts as a Delegator and is unable to host an entire FSC setup because of a lack of IT knowledge.
+This situation is not uncommon for Peers who participate as Delegator, they want to delegate the publication and consumption of Services because they miss the required knowledge to do it themselves.
+
+A Distribute-Only-Peer is a Peer who will only send requests and will not receive Signatures and Contracts from other Peers. A Peer can mark itself as a Distribute-Only-Peer by providing a `-` as Manager adres when announcing itself to other Peers.
+When a Peer creates or signs a Contract, the Peer does not need to distribute the Contract/Signature to Distribute-Only-Peers.
+Because a Distribute-Only-Peer is unreachable, it opens up the possibility to create tools which allow Delegators without advanced IT knowledge to participate in an FSC Group. E.g., a mobile app for signing Contracts. 
+
 ## Use cases and required components
 
 Which components a Peer needs depends on the use case.
@@ -165,4 +174,6 @@ A Peer who wants to consume Services needs a Manager and an Outway.
 
 A Peer who wants to offer Services needs a Manager and an Inway.    
 
-A Peer who wants to both consume and offer Services needs a Manager,an Outway and an Inway.  
+A Peer who wants to both consume and offer Services needs a Manager, an Outway and an Inway.  
+
+A Peer who wants to delegate the authorization to publish and/or consume Services to another Peer needs a Manager.

--- a/introduction.md
+++ b/introduction.md
@@ -25,6 +25,10 @@ This specification lists terms and abbreviations as used in this document.
 
 Actor that provides and/or consumes Services. This is an abstraction of e.g. an organization, a department or a security context.
 
+*Distribute-Only-Peer*
+
+Actor who participates only as a Delegator. This Peer is not able to receive management and/or data traffic from other Peers.
+
 *Group:*
 
 System of Peers using Inways, Outways and Managers that confirm to the FSC specification to make use of each other's Services.

--- a/manager.yaml
+++ b/manager.yaml
@@ -426,7 +426,7 @@ components:
     headerFscManagerAddress:
       in: header
       name: fsc-manager-address
-      description: The URL of the Manager. The scheme must be https and the URL must contain the port.
+      description: The URL of the Manager. The scheme must be https and the URL must contain the port. Or, in case of a Distribute-Only-Peer, the value `-` is allowed.
       schema:
         type: string
         example: https://manager.com:8443

--- a/specifications.md
+++ b/specifications.md
@@ -10,7 +10,7 @@ The protocol used between the Inway and Outway can be either HTTP/1.1[[RFC9112]]
 
 ### Port configuration
 
-In order to provide a predictable network configuration FSC limits the selection of network ports to be used by components. 
+In order to provide a predictable network configuration, FSC limits the selection of network ports to be used by components. 
 The ports used by FSC components **MUST** be `443` or `8443`. 
 
 Port `443` is **RECOMMENDED** for data traffic i.e. HTTP requests to a Service.  
@@ -228,6 +228,8 @@ A signature on a Contract **SHOULD** only be accepted if the Peer is present in 
 - `grant.data.service.delegator.peer_id`
 
 The JWS **MUST** specify the certificate thumbprint of the keypair used to create the digital signature using the `x5t#S256` [section 4.1.8](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.8) of [[RFC7515]] field of the `JOSE Header` [section 4](https://www.rfc-editor.org/rfc/rfc7515#section-4) of [[RFC7515]].
+
+The JWS **MUST** specify the certificate (chain) used to create the digital signature using the `x5c` [section 4.1.6](https://www.rfc-editor.org/rfc/rfc7515#section-4.1.8) of [[RFC7515]] field of the `JOSE Header` [section 4](https://www.rfc-editor.org/rfc/rfc7515#section-4) of [[RFC7515]].
 
 The JWS **MUST** use the JWS Compact Serialization described in [section 7.1](https://www.rfc-editor.org/rfc/rfc7515#section-7.1) of [[RFC7515]]
 
@@ -492,6 +494,8 @@ The Manager **MUST** validate Contracts using the rules described in [Contract v
 
 The Manager **MUST** persist the Peer ID, name and Manager address of each Peer with whom the Peer has negotiated Contracts.
 
+The Manager **MUST** propagate the Contract to each of the Peers in the Contract after creating it. Except for Peers who announced themselves as Distribute-Only-Peers.
+
 It is **RECOMMENDED** to implement a retry and backoff mechanism in case the Contract propagation fails.
 
 #### Signatures
@@ -500,7 +504,7 @@ The Manager **MUST** validate the signature according to the rules described in 
 
 The Manager **MUST** generate an error response if a signature is invalid.
 
-The Manager **MUST** propagate the signature to each of the Peers in the Contract when the Peer signs the Contract.
+The Manager **MUST** propagate the signature to each of the Peers in the Contract when the Peer signs the Contract. Except for Peers who announced themselves as Distribute-Only-Peers. 
 
 It is **RECOMMENDED** to implement a retry and backoff mechanism in case the signature propagation fails.
 
@@ -557,6 +561,8 @@ The `announce` is used to share the `Manager` address and `Peer` information amo
 Each `Peer` **MUST** call the `announce` endpoint of a Directory to register themselves as participant of the `Group`. 
 
 In addition to announcing to the `Directory` a Manager **SHOULD** call the `announce` endpoint of the Peers with whom the Peer has negotiated Contracts when the address of Manager changes.
+
+Distribute-Only-Peers `announce` themselves with the Manager address `-`.   
 
 ### Interfaces {#manager_interface}
 


### PR DESCRIPTION
A Distribute-Only-Peer is a Peer who will only send requests but is unable to receive them.
This Peer is introduced for the usecase of organizations who will want to participate as Delegator
but are missing the IT knowledge to deploy an entire FSC setup.
By adding a Peer that will only send requests new implementation possibilities are created.
For example a mobile app for signing contracts.
This is a breaking change because Peers will have to send the entire certificate when
signing Contracts instead of only the certificate thumbprint.
This is needed because Distribute-Only-Peers are unable to provide key material through a JWKS endpoint.
