### PR TITLE
Remove remaining instances of 'profile'

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -81,9 +81,6 @@ The Trust Anchor (TA) is an authoritative entity for which trust is assumed and 
 A list of one or more Trust Anchors. In the case of FSC, which uses an X.509 architecture, it is a list of all root certificates that are used as Trust Anchor. In practice this would be a list of one or more [Certificate Authorities](https://en.wikipedia.org/wiki/Certificate_authority) (CA's).
 Certificates issued by a CA that acts as a Trust Anchor are trusted within FSC Group.
 
-*Profile:* 
-
-A set of rules providing further restrictions and governance of the FSC Group. A Profile aligns on certain required parameters needed for the practical workings of an FSC Group. 
 
 ## Overall Operation of FSC Core
 
@@ -115,21 +112,23 @@ It is RECOMMENDED to use FSC Core with the following extensions, each specified 
 - [FSC Logging](https://gitdocumentatie.logius.nl/publicatie/fsc/logging/), keep a log of requests to Services.
 
 ### Group rules & restrictions {#group_rules}
+
 FSC Core provides the foundation for cooperation between organizations (Peers). However, in practice additional decisions have to be made to guarantee a functioning Group within a broader context.
 For example, it may be needed for a Group to have additional restrictions or agreements within the Group. Certain Group rules and restrictions are required for the operation of the Group, others provide optional agreements to enhance collaboration.
 
-The following decisions MUST be part of the Profile:
+The following decisions MUST be part of the Group:
+
 1. Select one or more [Trust Anchors](#trust_anchor) to include in the Trust Anchor list
 2. Select a [Group ID](#group_id)
 3. Select what determines the [Peer ID](#peer_id)
 4. Select what determines the [Peer name](#peer_name)
 5. Select at least one Peer who acts as the [Directory](#directory) of the Group
-
-6. Decide what ports are used for management traffic
+6. Decide what ports are used for Management traffic
 7. Determine requirements for allowed TLS versions and Cipher Suites 
 
 In addition to the mandatory decisions, a Group MAY also contain additional agreements or restrictions. These are not technically required for the operation of FSC Core, but can become mandatory within a Group. An example would be a set of additional rules in order to comply with local legislation.
 Below are a few examples listed of these additional decisions for inspirational purposes:
+
 1. Any extensions required by Peers within the Group
 2. Agreements on data retention
 3. The specifics of the retry mechanism used for Contract synchronization


### PR DESCRIPTION
Since we've decided to consolidate Group and Profile into 'Group', we should remove 'profile' everywhere.

Initial PR: https://github.com/Logius-standaarden/fsc-core/pull/3

Needs review from @RonaldKoster86 