### PR TITLE
Add error code for unknown FSC version

### DIFF
--- a/media/specs/manager.yaml
+++ b/media/specs/manager.yaml
@@ -530,6 +530,7 @@ components:
           example: 1672527600
           minimum: 0
       required:
+        - fsc_version
         - iv
         - group_id
         - validity

--- a/specifications.md
+++ b/specifications.md
@@ -636,6 +636,7 @@ The domain field of the error response MUST be equal to `ERROR_DOMAIN_MANAGER`.
 | ERROR_CODE_URL_PATH_CONTENT_HASH_MISMATCH           | 422              | The Content Hash in the URL path does not match the Content Hash generated from the Contract Content in the request body                           |
 | ERROR_CODE_UNKNOWN_HASH_ALGORITHM_HASH              | 422              | The Hash Algorithm in the Contract Content hash or Grant Hash is not supported                                                                     |
 | ERROR_CODE_UNKNOWN_ALGORITHM_SIGNATURE              | 422              | The Algorithm in the Signature is not supported                                                                                                    |
+| ERROR_CODE_UNKNOWN_FSC_VERSION                      | 422              | The FSC version in the Contract is unknown to the Manager                                                                                          |
 
 ## Directory {#directory}
 


### PR DESCRIPTION
If the Manager receives a Contract with an unknown FSC version, this error code should be returned.