### PR TITLE
Consistent Contract contentproperties

### DIFF
--- a/media/specs/manager.yaml
+++ b/media/specs/manager.yaml
@@ -33,13 +33,13 @@ paths:
             schema:
               type: object
               properties:
-                contract_content:
+                content:
                   $ref: "#/components/schemas/contractContent"
                 signature:
                   description: An accept signature of the Peer submitting the contract
                   type: string
               required:
-                - contract_content
+                - content
                 - signature
       responses:
         201:
@@ -469,14 +469,14 @@ components:
           schema:
             type: object
             properties:
-              contract_content:
+              content:
                 $ref: "#/components/schemas/contractContent"
               signature:
                 description: The signature
                 type: string
                 example: eyJhbGciOiJSUzUxMiIsIng1dCNTMjU2IjoiRzRYNEM0bmFXZmRERG5qSi9aV2RzNGFPcWhzVTZnUklPNlQxM1pMNEsyST0ifQ.eyJjb250ZW50SGFzaCI6IiQxJDEkWmFxbiszaWFoM2FkMmtuYjJKc2JhR2g2bi9rZ1UrUWpVK0pmTmhuVkdCd1RGbnN1TUNjOUlRcHlPM0xabmt0WUtaWWh4TnpKalh5RWlLMnVWZTZEZ3c9PSIsInR5cGUiOiJhY2NlcHQifQ.Qs7M3EBVWbrzhjPioDhbhNP8BJQqkxPOPq-Pm6oWL_ZO9m74TIeUHk1gQ1QcqZs_zGALjmDLuOSLLEgz3Qh4iK5jadex14z-i3xJObb5vcjVN326CxdJNzRZo60c9KWY4Nrh7ewziXJv8BQ3x4se62p5paCKdN8quWiG9J5gN4F5dmtZyae0rEhQsy-fy5ugLHPhR97cschr8OnlStVQKRYcUqn7obCnKLNOv-L9a02umsw6ha-G8CSMr3z9QZMfYcPABQAaR3XamUIR_T-ZGiZbpuTDaLfqztCP9jrZ7Q6g4J6SmQtxkcbzj4YdXXcwOr9aUO-07LZuH__tHGXU2bzgsObiClP5Fx13VT0zJzM5rdMtS5OnRwvznIFJUG1VkXXIRG9pVpffOM-kO-FsFW6BTWGi5nBJfi21nLUTh-bNVPB9O8WVfVBl8PwZ2HzjNy0asI_6I2jpweRh8-KNLM5ca18YS1VUS8cgfnc7qFcrnI8kxxDqyITOd2-LMRsngvmJpoJkmKjNIHbnJaoXdvMqFss7YHitJQi7wz3VUKLojK8XdaUc40KQtx7VIdBX9ClDdUFY1kXPxM_c0zLGsLn60a-4PLtUBZEPnBgxZd7-9st9ivBkPXylG9ZNqIe6aD4qxBtp91vI2w18X-MmYT-wb73PcF2IySAuzFk-uqI
             required:
-              - contract_content
+              - content
               - signature
   schemas:
     paginationResult:

--- a/specifications.md
+++ b/specifications.md
@@ -309,10 +309,10 @@ The Validation MUST be done every time a Peer receives a signature.
 The `contract_content_hash` of the signature payload contains the signature hash. The algorithm to create a `contract_content_hash` is described below. 
 The algorithm ensures that the content hash is unique for a specific Contract content. Because a signature contains the content hash, it becomes possible to guarantee that a signature is intended for a specific Contract.
 
-1. Convert `contract.content` to Canonical JSON data as described in [[RFC8785]].
-1. Hash the Canonical JSON data using the hash algorithm specified in `contract.content.hash_algorithm`.
+1. Convert the Contract `content` to Canonical JSON data as described in [[RFC8785]].
+1. Hash the Canonical JSON data using the hash algorithm specified in `content.hash_algorithm`.
 1. Encode the bytes of the hash using Base64 URL encoding with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or other additional characters.
-1. Convert the value of `contract.content.hash_algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`.
+1. Convert the value of `content.hash_algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`.
    To convert the hash algorithm to an integer, see the [type mapping](#type_mapping_hash_algorithm)
 1. Add `1$` as suffix to the string created in step 13. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. If the string created in step 13 is `$1$`, the result should now be `$1$1$`
 1. Add the Base64 generated in step 4 as suffix to the string generated in step 5.

--- a/specifications.md
+++ b/specifications.md
@@ -326,9 +326,9 @@ The Grant hash can be created by executing the following steps:
 1. Create the content hash as described in the [content hash](#content_hash) section. 
 1. Convert the content of `grant.data` to a Canonical JSON string as described in [[RFC8785]].
 1. Append the Canonical JSON string to the content hash.
-1. Hash the result of step 3 using the hash algorithm specified in `contract.content.algorithm`.
+1. Hash the result of step 3 using the hash algorithm specified in `content.hash_algorithm`.
 1. Encode the bytes of the hash using Base64 URL encoding with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or other additional characters.
-1. Convert the value of `contract.content.algorithm` to an int32 and enclose it with `$`. The int32 value per hash algorithm type is defined in the [type mapping](#type_mapping_hash_algorithm).. E.g. The enum `HASH_ALGORITHM_SHA3_512` becomes `$1$`.
+1. Convert the value of `content.hash_algorithm` to an int32 and enclose it with `$`. The int32 value per hash algorithm type is defined in the [type mapping](#type_mapping_hash_algorithm).. E.g. The enum `HASH_ALGORITHM_SHA3_512` becomes `$1$`.
 1. Determine the `HashType` that matches with value of `Grant.type` and convert it to an int32 and add a `$` as suffix. The int32 value per hash type is defined in the [type mapping](#type_mapping_hash). E.g. The enum `HASH_TYPE_SERVICE_PUBLICATION_GRANT` becomes `2$`.
 1. Combine the strings containing the hash algorithm (step 6) and Hash type (step 7). E.g. The hash algorithm `HASH_ALGORITHM_SHA3_512` and Grant Type `GRANT_TYPE_SERVICE_CONNECTION` should result in the string `$1$2$`
 1. Prefix the Base64 string generated in step 5 with the string generated in step 8.

--- a/specifications.md
+++ b/specifications.md
@@ -310,9 +310,9 @@ The `contract_content_hash` of the signature payload contains the signature hash
 The algorithm ensures that the content hash is unique for a specific Contract content. Because a signature contains the content hash, it becomes possible to guarantee that a signature is intended for a specific Contract.
 
 1. Convert `contract.content` to Canonical JSON data as described in [[RFC8785]].
-1. Hash the Canonical JSON data using the hash algorithm specified in `contract.content.algorithm`.
+1. Hash the Canonical JSON data using the hash algorithm specified in `contract.content.hash_algorithm`.
 1. Encode the bytes of the hash using Base64 URL encoding with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or other additional characters.
-1. Convert the value of `contract.content.algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`. 
+1. Convert the value of `contract.content.hash_algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`.
    To convert the hash algorithm to an integer, see the [type mapping](#type_mapping_hash_algorithm)
 1. Add `1$` as suffix to the string created in step 13. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. If the string created in step 13 is `$1$`, the result should now be `$1$1$`
 1. Add the Base64 generated in step 4 as suffix to the string generated in step 5.

--- a/specifications.md
+++ b/specifications.md
@@ -314,7 +314,7 @@ The algorithm ensures that the content hash is unique for a specific Contract co
 1. Encode the bytes of the hash using Base64 URL encoding with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or other additional characters.
 1. Convert the value of `content.hash_algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`.
    To convert the hash algorithm to an integer, see the [type mapping](#type_mapping_hash_algorithm)
-1. Add `1$` as suffix to the string created in step 13. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. If the string created in step 13 is `$1$`, the result should now be `$1$1$`
+1. Add `1$` as suffix to the string created in step 4. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. If the string created in step 13 is `$1$`, the result should now be `$1$1$`
 1. Add the Base64 generated in step 4 as suffix to the string generated in step 5.
 
 ### Grant hash {#grant_hash}


### PR DESCRIPTION
1. We gebruikten de property `content` voor het `GET /contracts` endpoint en `contract_content` voor het `POST /contracts` endpoint.
Ook de endpoints `PUT /contracts/{hash}/accept / reject / revoke` maakten gebruik van `contract_content`.
Dat is verwarrend. In deze PR hebben we alle instanties aangepast van `contract_content` naar `content`.
2. In de sectie 'Content hash' en 'Grant hash' werd gerefereerd naar de property `content.algorithm`. Die bestaat niet, dat moet `content.hash_algorithm` zijn.
