### PR TITLE
Voeg workflow toe voor label updates

### DIFF
--- a/.github/workflows/label-updates.yml
+++ b/.github/workflows/label-updates.yml
@@ -1,0 +1,13 @@
+name: Update labels
+on:
+  pull_request_review:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - closed
+
+jobs:
+  update-labels:
+    name: Update labels
+    uses: Logius-standaarden/Automatisering/.github/workflows/label-updates.yml@main


### PR DESCRIPTION
Hiermee worden automatisch `Status:` labels toegevoegd aan PRs als er activiteit op komt (openen, closen of een review).