### PR TITLE
refactor: rewrite the hashing steps to make it more clear

### DIFF
--- a/specifications.md
+++ b/specifications.md
@@ -317,10 +317,9 @@ The algorithm ensures that the content hash is unique for a specific Contract co
 1. Convert the Contract `content` to Canonical JSON data as described in [[RFC8785]].
 1. Hash the Canonical JSON data using the hash algorithm specified in `content.hash_algorithm`.
 1. Encode the bytes of the hash using Base64 URL encoding with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or other additional characters.
-1. Convert the value of `content.hash_algorithm` to an int32 and surround it with dollar signs (`$`). When using the `SHA3-512` algorithm this would result in `$1$`.
-   To convert the hash algorithm to an integer, see the [type mapping](#type_mapping_hash_algorithm)
-1. Add `1$` as suffix to the string created in step 4. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. If the string created in step 13 is `$1$`, the result should now be `$1$1$`
-1. Add the Base64 generated in step 4 as suffix to the string generated in step 5.
+1. Convert the value of `content.hash_algorithm` to an int32 and enclose it with `$`. The int32 value per hash algorithm type is defined in the [type mapping](#type_mapping_hash_algorithm). E.g. The enum `HASH_ALGORITHM_SHA3_512` becomes `$1$`.
+1. Add `1$` as suffix to the string created in step 4. This is the enum `HASH_TYPE_CONTRACT` as defined in the field `.components.schemas.HashType` of the [OpenAPI Specification](media/specs/manager.yaml) as int32. E.g. If the string created in step 4 is `$1$`, the result of this step should be `$1$1$`
+1. Prefix the Base64 string generated in step 3 with the string generated in step 5.
 
 ### Grant hash {#grant_hash}
 


### PR DESCRIPTION
Use the same phrasing in the content hash and grant hash sections and reference the correct steps.