### PR TITLE
add security scheme to OAS

### DIFF
--- a/media/specs/manager.yaml
+++ b/media/specs/manager.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: FSC Core
   version: 1.0.0
@@ -9,6 +9,8 @@ servers:
       managerUrl:
         default: localhost
         description: URL of the Manager
+security:
+  - mtls: []
 paths:
   /announce:
     put:
@@ -414,6 +416,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/jwks"
 components:
+  securitySchemes:
+    mtls:
+      type: mutualTLS
   parameters:
     pathContractContentHash:
       in: path


### PR DESCRIPTION
mTLS is mandatory when connecting to the Manager
Update OAS to 3.1.1.
OAS 3.1.* has security scheme support